### PR TITLE
Add params and multi as parameters when using execute command

### DIFF
--- a/coralinedb/coralinedb.py
+++ b/coralinedb/coralinedb.py
@@ -242,20 +242,21 @@ class BaseDB:
 
         return result
 
-    def execute(self, sql_statement, db_name=None, params=None):
+    def execute(self, sql_statement, db_name=None, params=None, multi=False):
         """
         Execute SQL Statement to database
         :param sql_statement: sql statement (str)
         :param db_name: database name (str)
-        :param params: parameters to cast the %s in sql statement (tuple or dictionary), for usecase read the link below
+        :param params: cast the %s in sql statement (tuple or dictionary), for usecase read the link below
                     https://dev.mysql.com/doc/connector-python/en/connector-python-api-mysqlcursor-execute.html
+        :param multi: is able to execute multiple sql statement within one execution (bool)
         :return:
         """
         # Create Connection
         engine, connection = self.create_connection(db_name)
 
         # Execute SQL
-        result = connection.execute(sql_statement, params)
+        result = connection.execute(sql_statement, params, multi)
 
         # Close connection
         connection.close()

--- a/coralinedb/coralinedb.py
+++ b/coralinedb/coralinedb.py
@@ -242,18 +242,20 @@ class BaseDB:
 
         return result
 
-    def execute(self, sql_statement, db_name=None):
+    def execute(self, sql_statement, db_name=None, params=None):
         """
         Execute SQL Statement to database
         :param sql_statement: sql statement (str)
         :param db_name: database name (str)
+        :param params: parameters to cast the %s in sql statement (tuple or dictionary), for usecase read the link below
+                    https://dev.mysql.com/doc/connector-python/en/connector-python-api-mysqlcursor-execute.html
         :return:
         """
         # Create Connection
         engine, connection = self.create_connection(db_name)
 
         # Execute SQL
-        result = connection.execute(sql_statement)
+        result = connection.execute(sql_statement, params)
 
         # Close connection
         connection.close()

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import find_packages
 setup(
     name='coralinedb',
     packages=find_packages(),
-    version='2.3',
+    version='2.4',
     description='Coraline Database Manager Package',
     long_description="""
     Coraline Database Manager Package


### PR DESCRIPTION
- add params to avoid unsupported format in Python (Python sees the % as a code to format string)
- add multi to allow using multiple query executions 